### PR TITLE
Update 2017_03_29_000000_avored_framework_schema.php

### DIFF
--- a/database/migrations/2017_03_29_000000_avored_framework_schema.php
+++ b/database/migrations/2017_03_29_000000_avored_framework_schema.php
@@ -284,13 +284,15 @@ class AvoredFrameworkSchema extends Migration
             $table->foreign('attribute_id')->references('id')->on('attributes');
             $table->foreign('attribute_dropdown_option_id')->references('id')->on('attribute_dropdown_options');
         });
-
-        Schema::create('configurations', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('configuration_key')->nullable()->default(null);
-            $table->string('configuration_value',999)->nullable()->default(null);
-            $table->timestamps();
-        });
+        
+        if (!Schema::hasTable('configurations')) {
+            Schema::create('configurations', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('configuration_key')->nullable()->default(null);
+                $table->string('configuration_value',999)->nullable()->default(null);
+                $table->timestamps();
+            });
+        };
     }
 
     /**


### PR DESCRIPTION
Error with installing
Illuminate\Database\QueryException : SQLSTATE[42S01]: Base table or view already exists: 1050 Table 'avored_configurations' already exists (SQL: create tableavored_configurations(idint unsigned not null auto_increment primary key,configuration_keyvarchar(255) null,configuration_valuevarchar(999) null,created_attimestamp null,updated_at` timestamp null) default character set utf8 collate 'utf8_unicode_ci' engine = InnoDB)

at C:\laragon\www\laravel-ecommerce\vendor\laravel\framework\src\Illuminate\Database\Connection.php: 664
660: // If an exception occurs when attempting to run a query, we'll format the error
661: // message to include the bindings with SQL, which will make this exception a
662: // lot more helpful to the developer instead of just the database's errors.
663: catch (Exception $e) {
664: throw new QueryException(
665: $query, $this->prepareBindings($bindings), $e
666: );
667: }
668:
669: return $result;

Exception trace:

1 PDOException::("SQLSTATE[42S01]: Base table or view already exists: 1050 Table 'avored_configurations' already exists")
C:\laragon\www\laravel-ecommerce\vendor\laravel\framework\src\Illuminate\Database\Connection.php : 458

2 PDOStatement::execute()
C:\laragon\www\laravel-ecommerce\vendor\laravel\framework\src\Illuminate\Database\Connection.php : 458

Please use the argument -v to see more details.`

Solved:
Check existe table configurations