### PR TITLE
Fixed error with currencySymbol variable

### DIFF
--- a/src/System/Middleware/SiteCurrencyMiddleware.php
+++ b/src/System/Middleware/SiteCurrencyMiddleware.php
@@ -75,6 +75,9 @@ class SiteCurrencyMiddleware
 
             $currencyCode = $siteCurrencyModel->code;
             $currencySymbol = $siteCurrencyModel->symbol;
+        } else {
+            $siteCurrencyModel = $this->curRep->findByCode($currencyCode);
+            $currencySymbol = $siteCurrencyModel->symbol;
         }
 
         $sessionCode = Session::get('currency_code', $currencyCode);


### PR DESCRIPTION
when select some currency in the store appear "Undefined variable: currencySymbol" because the currencySymbol only is inicialited if the currencyCode is null

#### Please do a all Pull Request on Dev Branch please

https://github.com/avored/framework/tree/dev

## Information about these Pull Request

