### PR TITLE
Use Laravel auth middleware

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -46,7 +46,7 @@ Route::middleware(['web'])
             ->name('logout');
     });
 
-Route::middleware(['web', 'admin.auth', 'permission'])
+Route::middleware(['web', 'admin.auth:admin', 'permission'])
     ->prefix($baseAdminUrl)
     ->namespace('AvoRed\Framework')
     ->name('admin.')

--- a/src/Support/Middleware/AdminAuth.php
+++ b/src/Support/Middleware/AdminAuth.php
@@ -2,25 +2,20 @@
 
 namespace AvoRed\Framework\Support\Middleware;
 
-use Closure;
-use Illuminate\Support\Facades\Auth;
+use Illuminate\Auth\Middleware\Authenticate as Middleware;
 
-class AdminAuth
+class AdminAuth extends Middleware
 {
     /**
-     * Handle an incoming request.
+     * Get the path the user should be redirected to when they are not authenticated.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
-     * @param  string|null  $guard
-     * @return mixed
+     * @return string
      */
-    public function handle($request, Closure $next, $guard = 'admin')
+    protected function redirectTo($request)
     {
-        if (! Auth::guard($guard)->check()) {
-            return redirect()->route('admin.login');
+        if (! $request->expectsJson()) {
+            return route('admin.login');
         }
-
-        return $next($request);
     }
 }

--- a/tests/Controllers/AuthTest.php
+++ b/tests/Controllers/AuthTest.php
@@ -50,4 +50,10 @@ class AuthTest extends BaseTestCase
             ->post(route('admin.login.post', ['email' => $this->user->email, 'password' => 'wrongpassword']))
             ->assertSessionHasErrors('email');
     }
+
+    public function testGuestUserIsRedirectedToLogin()
+    {
+        $this->get(route('admin.dashboard'))
+            ->assertRedirect(route('admin.login'));
+    }
 }


### PR DESCRIPTION
Use Laravel default authentication middleware, just as it is used in the [e-commerce](https://github.com/avored/laravel-ecommerce/blob/master/app/Http/Middleware/Authenticate.php) app.

This will make easier to integrate the Permission module with Laravel authorization gates in the future.