### PR TITLE
'method_exists' function param Object|String, request null

### DIFF
--- a/src/Database/Models/Page.php
+++ b/src/Database/Models/Page.php
@@ -28,7 +28,7 @@ class Page extends BaseModel
         $pattern = sprintf('/(@)?%s\s*(.+?)\s*%s(\r?\n)?/s', $this->contentTags[0], $this->contentTags[1]);
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3] . $matches[3];
-            $widget = Widget::get($matches[2]);
+            $widget = Widget::get($matches[2]) ?? '';
             
             if (method_exists($widget, 'render')) {
                 $widgetContent = $widget->render();


### PR DESCRIPTION
#### Please do a all Pull Request on Dev Branch please

https://github.com/avored/framework/tree/dev

## Information about these Pull Request

Exception
method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given (View: /Users/solomon/PhpstormProjects/laravel-ecommerce/resources/views/home.blade.php)


php function `method_exists` first param obejct|string

https://www.php.net/manual/en/function.method-exists
method_exists(object|string $object_or_class, string $method): bool