### PR TITLE
package config improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Once this is finished, you will need to run a few commands to finish up and then
 ## Publish the files
 Publish the AvoRed E-commerce framework config file and assets (JS/CSS and images):
 
+    php artisan vendor:publish --provider="Rebing\GraphQL\GraphQLServiceProvider"
     php artisan vendor:publish --provider="AvoRed\Framework\AvoRedServiceProvider"
 
 Once all the files are published, we can run the command to install the required database tables.

--- a/config/avored.php
+++ b/config/avored.php
@@ -15,7 +15,6 @@ use AvoRed\Framework\Graphql\Queries\AllAddressQuery;
 use AvoRed\Framework\Graphql\Queries\AllCategoryQuery;
 use AvoRed\Framework\Graphql\Queries\AllOrdersQuery;
 use AvoRed\Framework\Graphql\Queries\OrderQuery;
-use AvoRed\Framework\Graphql\Queries\CartItems;
 use AvoRed\Framework\Graphql\Queries\CartItemsQuery;
 use AvoRed\Framework\Graphql\Queries\CategoryQuery;
 use AvoRed\Framework\Graphql\Queries\CountryOptionsQuery;
@@ -75,7 +74,6 @@ return [
                 'model' => AvoRed\Framework\Database\Models\Customer::class,
             ],
         ],
-
         'passwords' => [
             'adminusers' => [
                 'provider' => 'admin-users',
@@ -90,7 +88,6 @@ return [
         ],
     ],
     'graphql' => [
-        'default_schema' => 'default',
         'schemas' => [
             'default' => [
                 'query' => [
@@ -121,13 +118,10 @@ return [
                     'addToCart' => AddToCartMutation::class,
                     'updateCart' => UpdateCartMutation::class,
                     'deleteCart' => DeleteCartMutation::class,
-                    'CreateSubscriberMutation' => CreateSubscriberMutation::class,
+                    'createSubscriberMutation' => CreateSubscriberMutation::class,
                 ],
-                'middleware' => [],
-                'method'     => ['GET', 'POST'],
             ],
         ],
-
         'types' => [
             'Category' => CategoryType::class,
             'Product' => ProductType::class,

--- a/src/AvoRedServiceProvider.php
+++ b/src/AvoRedServiceProvider.php
@@ -49,14 +49,15 @@ class AvoRedServiceProvider extends ServiceProvider
     ];
 
     /**
-     * Register services.
+     * Register any application services.
+     *
      * @return void
      */
     public function register()
     {
         $this->ignorePassport();
-        $this->registerProviders();
         $this->registerConfigData();
+        $this->registerProviders();
         $this->registerRoutePath();
         $this->registerMiddleware();
         // $this->registerViewComposerData();
@@ -68,7 +69,8 @@ class AvoRedServiceProvider extends ServiceProvider
     }
 
     /**
-     * Bootstrap services.
+     * Bootstrap any package services.
+     *
      * @return void
      */
     public function boot()
@@ -164,17 +166,10 @@ class AvoRedServiceProvider extends ServiceProvider
      */
     public function registerConfigData()
     {
-        $this->mergeConfigFrom(
-            __DIR__ . '/../config/avored.php',
-            'avored'
-        );
-        $avoredConfigData = include __DIR__ . '/../config/avored.php';
-        $authConfig = $this->app['config']->get('auth', []);
+        $this->mergeConfigFrom(__DIR__ . '/../config/avored.php', 'avored');
 
-        // $this->app['config']->set(
-        //     'passport.client_uuids',
-        //     true
-        // );
+        $avoredConfigData = $this->app['config']->get('avored', []);
+        $authConfig = $this->app['config']->get('auth', []);
 
         $this->app['config']->set(
             'auth.guards',

--- a/src/Support/Providers/GraphqlProvider.php
+++ b/src/Support/Providers/GraphqlProvider.php
@@ -23,8 +23,8 @@ class GraphqlProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->registerConfigData();
         $this->registerRebingLaravelGraphQlProvider();
+        $this->registerConfigData();
     }
 
     /**
@@ -37,14 +37,15 @@ class GraphqlProvider extends ServiceProvider
         App::register(GraphQLServiceProvider::class);
     }
 
-
     /**
      * Register config data for AvoRed E commerce Framework
      * @return void
      */
     public function registerConfigData()
     {
-        $avoredConfigData = include __DIR__ . '/../../../config/avored.php';
-        $this->app['config']->set('graphql', $avoredConfigData['graphql']);
+        $graphql_conf = $this->app['config']->get('graphql', []);
+        $avored_conf = $this->app['config']->get('avored', []);
+
+        $this->app['config']->set('graphql', array_merge_recursive($graphql_conf, $avored_conf['graphql']));
     }
 }


### PR DESCRIPTION
I've done some work in order to get a better experience when working with graphql configuration since there were some major problems:

- `src/AvoRedServiceProvider.php->register()` Avored should register its package config first in order to have access to those configurations latter on in `src/Support/Providers/GraphqlProvider.php->registerConfigData()`
- `src/Support/Providers/GraphqlProvider.php->registerConfigData()` was always loading default package data instead of configurations from `config/avored.php` and overriting all graphql package configurations, now those ones will merge
- `src/Support/Providers/GraphqlProvider.php->register()` grapqhl service provider should be registered first because Avored is using it's configuration
- documentation was updated because GraphqlServiceProvider doesn't load it's configuration when avored registers it